### PR TITLE
Support literal objects in _split_extension_config

### DIFF
--- a/markups/markdown.py
+++ b/markups/markdown.py
@@ -102,6 +102,16 @@ class MarkdownMarkup(AbstractMarkup):
 		if lb == -1:
 			return extension_name, {}
 		extension_name, parameters = extension_name[:lb], extension_name[lb + 1:-1]
+
+		try: #try parse extension config using python abstract syntax
+			import ast
+			ast_obj, kwargs = ast.parse('f(%s)'%parameters).body[0].value, {}
+			if isinstance(ast_obj, ast.Call):
+				kwargs = {arg.arg: ast.literal_eval(arg.value) for arg in ast_obj.keywords}
+			return extension_name, kwargs
+		except (SyntaxError, ValueError):
+			pass #extension parameters using legacy syntax
+
 		pairs = [x.split("=") for x in parameters.split(",")]
 		return extension_name, {x.strip(): y.strip() for (x, y) in pairs}
 

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -194,6 +194,36 @@ class MarkdownTest(unittest.TestCase):
 			'<h3 id="header">Header</h3>\n'
 			'<p><a class="wikilink" href="/Link/">Link</a></p>\n')
 
+	def test_document_extensions_parameters_ast(self):
+		markup = MarkdownMarkup(extensions=[])
+		toc_header = '<!--- Required extensions: toc(anchorlink=True, baselevel=2) --->\n\n'
+		html = markup.convert(toc_header + '## Header').get_document_body()
+		self.assertEqual(html, toc_header +
+			'<h3 id="header"><a class="toclink" href="#header">Header</a></h3>\n')
+		toc_header = '<!--- Required extensions: toc(title="Table of contents", baselevel=3) wikilinks --->\n\n'
+		html = markup.convert(toc_header + '[TOC]\n\n# Header\n[[Link]]').get_document_body()
+		self.assertEqual(html, toc_header +
+			'<div class="toc"><span class="toctitle">Table of contents</span><ul>\n'
+			'<li><a href="#header">Header</a></li>\n'
+			'</ul>\n</div>\n'
+			'<h3 id="header">Header</h3>\n'
+			'<p><a class="wikilink" href="/Link/">Link</a></p>\n')
+
+	def test_document_extensions_parameters_backward_compatibility(self):
+		markup = MarkdownMarkup(extensions=[])
+		toc_header = '<!--- Required extensions: toc(anchorlink=True, baselevel=2) --->\n\n'
+		html = markup.convert(toc_header + '## Header').get_document_body()
+		self.assertEqual(html, toc_header +
+			'<h3 id="header"><a class="toclink" href="#header">Header</a></h3>\n')
+		toc_header = '<!--- Required extensions: toc(title=Table of contents, baselevel=3) wikilinks --->\n\n'
+		html = markup.convert(toc_header + '[TOC]\n\n# Header\n[[Link]]').get_document_body()
+		self.assertEqual(html, toc_header +
+			'<div class="toc"><span class="toctitle">Table of contents</span><ul>\n'
+			'<li><a href="#header">Header</a></li>\n'
+			'</ul>\n</div>\n'
+			'<h3 id="header">Header</h3>\n'
+			'<p><a class="wikilink" href="/Link/">Link</a></p>\n')
+
 	def test_extra(self):
 		markup = MarkdownMarkup()
 		html = markup.convert(tables_source).get_document_body()


### PR DESCRIPTION
Some extensions need objects as a configuration parameter. This new approach enables pass literal objects as a parameter to extensions.

**Example:**
With this change its possible pass the **_options_** parameter for emojis in emoji.py extension 

`<!-- Required extensions: pymdownx.emoji(options={'attributes':{'align': 'absmiddle','height': '16px','width': '16px'}})-->`
