### PR TITLE
adapt to Pygments 2.19

### DIFF
--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -41,7 +41,7 @@ class APITest(unittest.TestCase):
         except ImportError:
             raise unittest.SkipTest("Pygments not available")
         stylesheet = get_pygments_stylesheet(".selector")
-        self.assertIn(".selector .nf { color: #0000FF", stylesheet)
+        self.assertIn(".selector .nf { color: #00F", stylesheet)
         stylesheet = get_pygments_stylesheet(".selector", style="colorful")
-        self.assertIn(".selector .nf { color: #0066BB", stylesheet)
+        self.assertIn(".selector .nf { color: #06B", stylesheet)
         self.assertFalse(get_pygments_stylesheet(".selector", style=""))


### PR DESCRIPTION
Pygments 2.19 started shortening the repeating hexadecimal digits.